### PR TITLE
Fix config not found on mac/linux and errors with empty config

### DIFF
--- a/DraggableWindows/DragWindow.cs
+++ b/DraggableWindows/DragWindow.cs
@@ -29,7 +29,7 @@ public class DragWindow : MonoBehaviour, IDragHandler
     {
         string path = Application.persistentDataPath + "/DraggableWindowsSettings.json";
         string settingsJsonFile = File.ReadAllText(path);
-        JSONObject settingsJson = (JSONObject)JSON.Parse(settingsJsonFile);
-        return settingsJson["ShiftEnabled"];
+        JSONObject settingsJson = JSON.Parse(settingsJsonFile) as JSONObject;
+        return settingsJson?["ShiftEnabled"] ?? false;
     }
 }

--- a/DraggableWindows/Plugin.cs
+++ b/DraggableWindows/Plugin.cs
@@ -148,10 +148,10 @@ namespace DraggableWindows
         private void EnsureJsonfileExists()
         {
             string AppdataPath = GetAppdataFolder();
-            if (!File.Exists(AppdataPath + "\\" + DraggableWindowsSettingsFile))
+            if (!File.Exists(AppdataPath + "/" + DraggableWindowsSettingsFile))
             {
                 // Create Json file under app data if not found
-                File.Create(AppdataPath + "\\" + DraggableWindowsSettingsFile);
+                File.Create(AppdataPath + "/" + DraggableWindowsSettingsFile);
                 Debug.Log(DraggableWindowsSettingsFile + " has been created in: " + AppdataPath);
             }
         }


### PR DESCRIPTION
`\` is windows only, `/` works everywhere.

And the config file only has valid JSON after the shift setting has been toggled at least once.